### PR TITLE
add support for alternate TextAsset translation

### DIFF
--- a/AI_TextResourceHelper/AI_TextResourceHelper.cs
+++ b/AI_TextResourceHelper/AI_TextResourceHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using BepInEx.Logging;
 
 namespace KK_Plugins
 {

--- a/AI_TextResourceRedirector/AI.TextResourceRedirector.cs
+++ b/AI_TextResourceRedirector/AI.TextResourceRedirector.cs
@@ -10,5 +10,6 @@ namespace KK_Plugins
         public const string PluginNameInternal = "AI_TextResourceRedirector";
 
         private TextResourceHelper GetTextResourceHelper() => new AI_TextResourceHelper();
+        private TextAssetHelper GetTextAssetHelper() => null;
     }
 }

--- a/AI_TextResourceRedirector/AI_TextResourceRedirector.csproj
+++ b/AI_TextResourceRedirector/AI_TextResourceRedirector.csproj
@@ -40,6 +40,14 @@
       <HintPath>..\packages\IllusionLibs.BepInEx.5.0.0\lib\net46\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="MonoMod.RuntimeDetour, Version=19.11.5.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.MonoMod.19.11.5.1\lib\net46\MonoMod.RuntimeDetour.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod.Utils, Version=19.11.5.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.MonoMod.19.11.5.1\lib\net46\MonoMod.Utils.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/AI_TextResourceRedirector/packages.config
+++ b/AI_TextResourceRedirector/packages.config
@@ -3,6 +3,7 @@
   <package id="IllusionLibs.AIGirl.Assembly-CSharp" version="2019.11.8" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.AIGirl.UnityEngine.CoreModule" version="2018.2.21" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.BepInEx" version="5.0.0" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.MonoMod" version="19.11.5.1" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" version="4.6.4" targetFramework="net46" developmentDependency="true" />
   <package id="IllusionLibs.XUnity.ResourceRedirector" version="4.6.4.1" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Core_TextResourceHelper/Core.TextAssetHelper.cs
+++ b/Core_TextResourceHelper/Core.TextAssetHelper.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace KK_Plugins
+{
+    public class TextAssetHelper
+    {
+        public bool Enabled { get; }
+        public IEnumerable<string> RowSplitStrings { get; }
+        public IEnumerable<string> ColSplitStrings { get; }
+        public IEnumerable<string> InvalidColStrings { get; }
+
+        public TextAssetHelper(IEnumerable<string> rowSplitStrings = null, IEnumerable<string> colSplitStrings = null)
+        {
+            int comp(string a, string b) => b.Length.CompareTo(a.Length);
+
+            List<string> tmpList = new List<string>();
+
+            // row split strings
+            tmpList.AddRange(rowSplitStrings?.ToArray() ?? new string[0]);
+            tmpList.Sort(comp);
+            RowSplitStrings = tmpList.ToArray();
+
+            // col split strings
+            tmpList.Clear();
+            tmpList.AddRange(colSplitStrings?.ToArray() ?? new string[0]);
+            tmpList.Sort(comp);
+            ColSplitStrings = tmpList.ToArray();
+
+            // invalid col strings
+            tmpList.Clear();
+            tmpList.AddRange(RowSplitStrings);
+            tmpList.AddRange(ColSplitStrings);
+            tmpList.Sort(comp);
+            InvalidColStrings = tmpList.ToArray();
+
+            Enabled = ColSplitStrings.Any() && RowSplitStrings.Any();
+
+        }
+
+        public bool IsTable(TextAsset textAsset)
+        {
+            return IsTable(textAsset.text);
+        }
+
+        public bool IsTable(string table)
+        {
+            foreach (string colSplit in ColSplitStrings)
+            {
+                if (table.Contains(colSplit))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public bool IsTableRow(string row)
+        {
+            foreach (string rowSplit in ColSplitStrings)
+            {
+                if (row.Contains(rowSplit))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public IEnumerable<string> SplitTableToRows(TextAsset textAsset)
+        {
+            return SplitTableToRows(textAsset.text);
+        }
+
+        public IEnumerable<string> SplitTableToRows(string table)
+        {
+            if (!IsTable(table))
+            {
+                throw new ArgumentException("textAsset does not contain a table");
+            }
+            return table.Split(RowSplitStrings.ToArray(), StringSplitOptions.None);
+        }
+
+        public IEnumerable<string> SplitRowToCells(string row)
+        {
+
+#if DEBUG
+            if (!IsTableRow(row))
+            {
+                throw new ArgumentException("row does not contain a table row)");
+            }
+#endif
+            return row.Split(ColSplitStrings.ToArray(), StringSplitOptions.None);
+        }
+
+        public void ActOnCells(TextAsset textAsset, Action<string> cellAction, out TableResult tableResult)
+        {
+            ActOnCells(textAsset, (cell) => { cellAction(cell); return false; }, out tableResult);
+        }
+
+        public bool ActOnCells(TextAsset textAsset, Func<string, bool> cellAction, out TableResult tableResult)
+        {
+            tableResult = new TableResult();
+            //foreach (string row in EnumerateRows(textAsset))
+            foreach (string row in SplitTableToRows(textAsset))
+            {
+                tableResult.Rows++;
+                int colCount = 0;
+
+                //foreach (string col in EnumerateCols(row))
+                foreach (string col in SplitRowToCells(row))
+                {
+                    colCount++;
+                    if (cellAction(col))
+                    {
+                        tableResult.CellsActedOn++;
+                    }
+                }
+                tableResult.Cols = Math.Max(tableResult.Cols, colCount);
+            }
+            return tableResult.CellsActedOn > 0;
+        }
+
+        public string ProcessTable(TextAsset textAsset, Func<string, string> columnTransform, out TableResult tableResult)
+        {
+            tableResult = new TableResult();
+            string colJoin = ColSplitStrings.First();
+            StringBuilder result = new StringBuilder(textAsset.text.Length * 2);
+            //foreach (string row in EnumerateRows(textAsset))
+            foreach (string row in SplitTableToRows(textAsset))
+            {
+                tableResult.Rows++;
+                int colCount = 0;
+
+                bool rowUpdated = false;
+                //foreach (string col in EnumerateCols(row))
+                foreach (string col in SplitRowToCells(row))
+                {
+                    colCount++;
+                    string newCol = columnTransform(col);
+                    if (newCol != null && col != newCol)
+                    {
+                        tableResult.CellsUpdated++;
+                        rowUpdated = true;
+                        foreach (string invalid in InvalidColStrings)
+                        {     
+                            newCol = newCol.Replace(invalid, " ");
+                        }
+                        result.Append(newCol);
+                    }
+                    else
+                    {
+                        result.Append(col);
+                    }
+                    result.Append(colJoin);
+                }
+                // row complete
+                // remove trailing colSplit
+                result.Length -= colJoin.Length;
+                result.Append(Environment.NewLine);
+                if (rowUpdated)
+                {
+                    tableResult.RowsUpdated++;
+                }
+                tableResult.Cols = Math.Max(tableResult.Cols, colCount);
+            }
+            // table complete
+            // remove last newline
+            result.Length -= Environment.NewLine.Length;
+
+            if (!tableResult.Updated)
+            {
+                return textAsset.text;
+            }
+            return result.ToString();
+        }
+
+        public class TableResult
+        {
+            public int Rows;
+            public int Cols;
+            public int RowsUpdated;
+            public int CellsUpdated;
+            public int CellsActedOn;
+
+            public TableResult()
+            {
+                Rows = Cols = RowsUpdated = CellsUpdated = CellsActedOn = 0;
+            }
+
+            public bool Updated { get => RowsUpdated > 0; }
+
+        }
+    }
+}

--- a/Core_TextResourceHelper/Core_TextResourceHelper.projitems
+++ b/Core_TextResourceHelper/Core_TextResourceHelper.projitems
@@ -10,5 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Core.TextResourceHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.TextAssetHelper.cs" />
   </ItemGroup>
 </Project>

--- a/Core_TextResourceRedirector/Core.TextResourceRedirector.ExcelData.cs
+++ b/Core_TextResourceRedirector/Core.TextResourceRedirector.ExcelData.cs
@@ -1,14 +1,20 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using XUnity.AutoTranslator.Plugin.Core;
 using XUnity.AutoTranslator.Plugin.Core.AssetRedirection;
 using XUnity.AutoTranslator.Plugin.Core.Utilities;
 using XUnity.ResourceRedirector;
+using BepInEx.Logging;
+
+
 
 namespace KK_Plugins
 {
     public class ExcelDataResourceRedirector : AssetLoadedHandlerBaseV2<ExcelData>
     {
+        private static ManualLogSource Logger => TextResourceRedirector.Logger;
+
         public ExcelDataResourceRedirector() => CheckDirectory = true;
 
         protected override string CalculateModificationFilePath(ExcelData asset, IAssetOrResourceLoadedContext context) =>

--- a/Core_TextResourceRedirector/Core.TextResourceRedirector.ScenarioData.cs
+++ b/Core_TextResourceRedirector/Core.TextResourceRedirector.ScenarioData.cs
@@ -1,5 +1,6 @@
 ﻿#if !HS
 using ADV;
+using BepInEx.Logging;
 using System;
 using System.IO;
 using System.Linq;
@@ -13,6 +14,7 @@ namespace KK_Plugins
     public class ScenarioDataResourceRedirector : AssetLoadedHandlerBaseV2<ScenarioData>
     {
         private readonly TextResourceHelper textResourceHelper;
+        private static ManualLogSource Logger => TextResourceRedirector.Logger;
 
         public ScenarioDataResourceRedirector(TextResourceHelper helper)
         {

--- a/Core_TextResourceRedirector/Core.TextResourceRedirector.TextAssetPatcher.cs
+++ b/Core_TextResourceRedirector/Core.TextResourceRedirector.TextAssetPatcher.cs
@@ -1,0 +1,93 @@
+﻿#if !HS
+using BepInEx.Logging;
+using MonoMod.RuntimeDetour;
+using System;
+using System.Reflection;
+using System.Text;
+using UnityEngine;
+
+namespace KK_Plugins
+{
+    using LogLevel = BepInEx.Logging.LogLevel;
+
+    public static class TextAssetPatcher
+    {
+        // Harmony can't patch these getters (empty bodies) so using MonoMod for now
+        // if this changes this class could be replaced with postfix patches
+        private static bool patched = false;
+        private static Func<TextAsset, string> textGetterOrig;
+        private static Func<TextAsset, byte[]> bytesGetterOrig;
+
+        private static ManualLogSource Logger => TextResourceRedirector.Logger;
+
+        public static void PatchTextAsset()
+        {
+            if (!patched)
+            {
+                textGetterOrig = PatchGetter<TextAsset, string>("text", TextGetterNew);
+                bytesGetterOrig = PatchGetter<TextAsset, byte[]>("bytes", BytesGetterNew);
+                patched = true;
+            }
+        }
+
+        internal static Func<T, TResult> PatchGetter<T, TResult>(string propertyToPatch, Func<T, TResult> replacementGetter)
+        {
+            BindingFlags baseFlags = BindingFlags.Public | BindingFlags.NonPublic;
+            MethodInfo origGetter = typeof(TextAsset).GetProperty(propertyToPatch, baseFlags | BindingFlags.Instance)?.GetGetMethod();
+            if (origGetter is null)
+            {
+                throw new ArgumentException($"Unable to patch { propertyToPatch }. Property not found.");
+            }
+
+            NativeDetour detour = new NativeDetour(origGetter, replacementGetter.Method);
+
+            detour.Apply();
+            Logger.Log(LogLevel.Debug, $"patched: {origGetter.ReturnType} {nameof(TextAsset)}.{origGetter.Name}()");
+            return detour.GenerateTrampoline<Func<T, TResult>>();
+        }
+
+        internal static string TextGetterOrig(this TextAsset obj)
+        {
+            if (patched)
+            {
+                return textGetterOrig(obj);
+            }
+            else
+            {
+                return obj.text;
+            }
+        }
+
+        internal static string TextGetterNew(this TextAsset obj)
+        {
+            string result = obj.TextGetterOrig();
+            if (patched && TextAssetResourceRedirector.TryLoadReplacement(result, out string replacement))
+            {
+                return replacement;
+            }
+            return result;
+        }
+
+        internal static byte[] BytesGetterOrig(this TextAsset obj)
+        {
+            if (patched)
+            {
+                return bytesGetterOrig(obj);
+            }
+            else
+            {
+                return obj.bytes;
+            }
+        }
+
+        internal static byte[] BytesGetterNew(this TextAsset obj)
+        {
+            if (patched && TextAssetResourceRedirector.TryLoadReplacement(obj.TextGetterOrig(), out string replacement))
+            {
+                return Encoding.ASCII.GetBytes(replacement);
+            }
+            return obj.BytesGetterOrig();
+        }
+    }
+}
+#endif

--- a/Core_TextResourceRedirector/Core.TextResourceRedirector.TextAssetResourceRedirector.cs
+++ b/Core_TextResourceRedirector/Core.TextResourceRedirector.TextAssetResourceRedirector.cs
@@ -1,0 +1,196 @@
+﻿#if !HS
+
+using BepInEx.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using XUnity.AutoTranslator.Plugin.Core;
+using XUnity.AutoTranslator.Plugin.Core.AssetRedirection;
+using XUnity.AutoTranslator.Plugin.Core.Utilities;
+using XUnity.ResourceRedirector;
+
+namespace KK_Plugins
+{
+    using BepinLogLevel = BepInEx.Logging.LogLevel;
+    public class TextAssetResourceRedirector : AssetLoadedHandlerBaseV2<TextAsset>
+    {
+        private readonly TextAssetHelper textAssetHelper;
+
+        private static readonly object replacementSync = new object();
+        private static readonly Dictionary<string, string> replacements = new Dictionary<string, string>();
+        private static readonly Dictionary<string, List<WeakReference>> replacementsTracker = new Dictionary<string, List<WeakReference>>();
+
+        protected static ManualLogSource Logger => TextResourceRedirector.Logger;
+
+        public bool Enabled => textAssetHelper?.Enabled ?? false;
+
+        public TextAssetResourceRedirector(TextAssetHelper textAssetHelper)
+        {
+            CheckDirectory = true;
+            this.textAssetHelper = textAssetHelper;
+            if (Enabled)
+            {
+                Logger.Log(BepinLogLevel.Info, $"{this.GetType()} enabled");
+                SceneManager.sceneLoaded += this.SceneManager_sceneLoaded;
+                TextAssetPatcher.PatchTextAsset();
+            }
+            else
+            {
+                Logger.Log(BepinLogLevel.Warning, $"{this.GetType()} disabled");
+            }
+        }
+
+        protected override string CalculateModificationFilePath(TextAsset asset, IAssetOrResourceLoadedContext context)
+        {
+            return context.GetPreferredFilePathWithCustomFileName(asset, null).Replace(".unity3d", "");
+        }
+
+        protected override bool DumpAsset(string calculatedModificationPath, TextAsset asset, IAssetOrResourceLoadedContext context)
+        {
+            if (!Enabled || !textAssetHelper.IsTable(asset))
+            {
+                return false;
+            }
+
+            var defaultTranslationFile = Path.Combine(calculatedModificationPath, "translation.txt");
+            var redirectedResources = RedirectedDirectory.GetFilesInDirectory(calculatedModificationPath, ".txt");
+            var streams = redirectedResources.Select(x => x.OpenStream());
+            var cache = new SimpleTextTranslationCache(
+               outputFile: defaultTranslationFile,
+               inputStreams: streams,
+               allowTranslationOverride: false,
+               closeStreams: true);
+
+            bool DumpCell(string cellText)
+            {
+                if (!string.IsNullOrEmpty(cellText) && LanguageHelper.IsTranslatable(cellText))
+                {
+                    cache.AddTranslationToCache(cellText, cellText);
+                    return true;
+                }
+                return false;
+            }
+
+            return textAssetHelper.ActOnCells(asset, DumpCell, out TextAssetHelper.TableResult tableResult);
+        }
+
+        protected override bool ReplaceOrUpdateAsset(string calculatedModificationPath, ref TextAsset asset, IAssetOrResourceLoadedContext context)
+        {
+            if (!Enabled || !textAssetHelper.IsTable(asset))
+            {
+                return false;
+            }
+
+            var defaultTranslationFile = Path.Combine(calculatedModificationPath, "translation.txt");
+            var redirectedResources = RedirectedDirectory.GetFilesInDirectory(calculatedModificationPath, ".txt");
+            var streams = redirectedResources.Select(x => x.OpenStream());
+            var cache = new SimpleTextTranslationCache(
+               outputFile: defaultTranslationFile,
+               inputStreams: streams,
+               allowTranslationOverride: false,
+               closeStreams: true);
+
+            return TryRegisterTranslation(cache, ref asset);
+        }
+
+        private bool TryRegisterTranslation(SimpleTextTranslationCache cache, ref TextAsset textAsset)
+        {
+            string TranslateCell(string cellText)
+            {
+                if (cache.TryGetTranslation(cellText, false, out string newText))
+                {
+                    return newText;
+                }
+                else
+                {
+                    if (AutoTranslatorSettings.IsDumpingRedirectedResourcesEnabled)
+                    {
+                        if (!string.IsNullOrEmpty(cellText) && LanguageHelper.IsTranslatable(cellText))
+                        {
+                            cache.AddTranslationToCache(cellText, cellText);
+                        }
+                    }
+                }
+                return null;
+            }
+
+            string result = textAssetHelper.ProcessTable(textAsset, TranslateCell, out TextAssetHelper.TableResult tableResult);
+            Logger.Log(BepinLogLevel.Debug, $"{this.GetType()}: {tableResult.RowsUpdated}/{tableResult.Rows} rows updated");
+            if (tableResult.RowsUpdated > 0)
+            {
+                RegisterReplacement(textAsset, result);
+                return true;
+            }
+            return false;
+        }
+
+        public static bool TryLoadReplacement(string orig, out string result)
+        {
+            return replacements.TryGetValue(orig, out result);
+        }
+
+        protected override bool ShouldHandleAsset(TextAsset asset, IAssetOrResourceLoadedContext context)
+        {
+            return Enabled && textAssetHelper.IsTable(asset) && !context.HasReferenceBeenRedirectedBefore(asset);
+        }
+
+        private static void RegisterReplacement(TextAsset textAsset, string replacement)
+        {
+            // Direct references to textAsset.text increments the TextAsset reference count
+            // preventing it from being garbage collected, so make a copy
+            string key = string.Copy(textAsset.TextGetterOrig());
+            lock (replacementSync)
+            {
+                replacements[key] = replacement;
+
+                WeakReference taRef = new WeakReference(textAsset);
+
+                if (!replacementsTracker.ContainsKey(key))
+                {
+                    replacementsTracker.Add(key, new List<WeakReference>());
+                }
+                replacementsTracker[key].Add(taRef);
+            }
+        }
+
+        private static void CleanupReplacements()
+        {
+            if (replacements.Count > 0)
+            {
+                int releasedCount = 0;
+                lock (replacementSync)
+                {
+                    foreach (string key in replacementsTracker.Keys.ToArray())
+                    {
+                        replacementsTracker[key].RemoveAll((m) => !m.IsAlive);
+                        if (replacementsTracker[key].Count == 0)
+                        {
+                            replacements.Remove(key);
+                            replacementsTracker.Remove(key);
+                            releasedCount++;
+                        }
+                    }
+                }
+                Logger.Log(BepinLogLevel.Debug, $"Released replacements for {releasedCount} unloaded TextAsset(s) (now loaded: {replacements.Count})");
+            }
+        }
+
+        private void SceneManager_sceneLoaded(Scene arg0, LoadSceneMode arg1)
+        {
+            CleanupReplacements();
+        }
+    }
+}
+
+#else //Stub for HS
+namespace KK_Plugins
+{
+    public class TextAssetResourceRedirector
+    {
+        public TextAssetResourceRedirector(TextAssetHelper textAssetHelper) { }
+    }
+}
+#endif

--- a/Core_TextResourceRedirector/Core.TextResourceRedirector.cs
+++ b/Core_TextResourceRedirector/Core.TextResourceRedirector.cs
@@ -1,4 +1,6 @@
 ﻿using BepInEx;
+using BepInEx.Logging;
+
 //Adopted from gravydevsupreme's TextResourceRedirector
 namespace KK_Plugins
 {
@@ -6,19 +8,30 @@ namespace KK_Plugins
     {
         public const string PluginName = "Text Resource Redirector";
         public const string GUID = "com.deathweasel.bepinex.textresourceredirector";
-        public const string Version = "1.1";
+        public const string Version = "1.1.1";
+        internal static new ManualLogSource Logger;
 
         internal ExcelDataResourceRedirector _excelRedirector;
         internal ScenarioDataResourceRedirector _scenarioRedirector;
+        internal TextAssetResourceRedirector _textAssetResourceRedirector;
         internal TextResourceHelper _textResourceHelper;
+        internal static TextAssetHelper _textAssetHelper;
 
         internal void Awake()
         {
+            Logger = Logger ?? base.Logger;
             _textResourceHelper = GetTextResourceHelper();
             _excelRedirector = new ExcelDataResourceRedirector();
             _scenarioRedirector = new ScenarioDataResourceRedirector(_textResourceHelper);
+            _textAssetHelper = GetTextAssetHelper();
+            _textAssetResourceRedirector = new TextAssetResourceRedirector(_textAssetHelper);
 
             enabled = false;
+        }
+
+        internal void Main()
+        {
+            Logger = Logger ?? base.Logger;
         }
     }
 }

--- a/Core_TextResourceRedirector/Core_TextResourceRedirector.projitems
+++ b/Core_TextResourceRedirector/Core_TextResourceRedirector.projitems
@@ -13,5 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Core.TextResourceRedirector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.TextResourceRedirector.ExcelData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Core.TextResourceRedirector.ScenarioData.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.TextResourceRedirector.TextAssetResourceRedirector.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Core.TextResourceRedirector.TextAssetPatcher.cs" />
   </ItemGroup>
 </Project>

--- a/HS_TextResourceRedirector/HS.TextResourceRedirector.cs
+++ b/HS_TextResourceRedirector/HS.TextResourceRedirector.cs
@@ -10,5 +10,6 @@ namespace KK_Plugins
         public const string PluginNameInternal = "HS_TextResourceRedirector";
 
         private TextResourceHelper GetTextResourceHelper() => null;
+        private TextAssetHelper GetTextAssetHelper() => null;
     }
 }

--- a/KK_TextResourceHelper/KK_TextResourceHelper.cs
+++ b/KK_TextResourceHelper/KK_TextResourceHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using BepInEx.Logging;
 
 namespace KK_Plugins
 {
@@ -9,6 +10,8 @@ namespace KK_Plugins
             CalcKeys = new HashSet<string>();
             FormatKeys = new HashSet<string>();
             TextKeysBlacklist = new HashSet<string>();
+
+            SupportedCommands[ADV.Command.Choice] = true;
         }
     }
 }

--- a/KK_TextResourceRedirector/KK.TextResourceRedirector.cs
+++ b/KK_TextResourceRedirector/KK.TextResourceRedirector.cs
@@ -10,5 +10,6 @@ namespace KK_Plugins
         public const string PluginNameInternal = "KK_TextResourceRedirector";
 
         private TextResourceHelper GetTextResourceHelper() => new KK_TextResourceHelper();
+        private TextAssetHelper GetTextAssetHelper() => new TextAssetHelper(new string[] { "\r\n", "\r", "\n" }, new string[] { "\t" });
     }
 }

--- a/KK_TextResourceRedirector/KK_TextResourceRedirector.csproj
+++ b/KK_TextResourceRedirector/KK_TextResourceRedirector.csproj
@@ -32,12 +32,28 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="0Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.0-beta\lib\net35\0Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27\lib\net35\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\IllusionLibs.BepInEx.5.0.0\lib\net35\BepInEx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.0-beta\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod.RuntimeDetour, Version=19.11.5.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.MonoMod.19.11.5.1\lib\net35\MonoMod.RuntimeDetour.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod.Utils, Version=19.11.5.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.MonoMod.19.11.5.1\lib\net35\MonoMod.Utils.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/KK_TextResourceRedirector/packages.config
+++ b/KK_TextResourceRedirector/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="IllusionLibs.BepInEx" version="5.0.0" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.0.0-beta" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.MonoMod" version="19.11.5.1" targetFramework="net35" developmentDependency="true" />
   <package id="IllusionLibs.Koikatu.Assembly-CSharp" version="2019.4.27" targetFramework="net35" developmentDependency="true" />
   <package id="IllusionLibs.Koikatu.UnityEngine" version="5.6.2" targetFramework="net35" developmentDependency="true" />
   <package id="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" version="4.6.4" targetFramework="net35" developmentDependency="true" />


### PR DESCRIPTION
Replaces strings by table cell, rather than entire table (restores loading of `h/list` files from `KoikatsuStoryTranslation`)