### PR TITLE
FKIK preserve neck control on scene load/character replacement (fix #38)

### DIFF
--- a/src/FKIK.Core/Core.FKIK.Hooks.cs
+++ b/src/FKIK.Core/Core.FKIK.Hooks.cs
@@ -13,6 +13,8 @@ namespace KK_Plugins
         {
             private static bool ChangingChara;
 
+            private static int ChangingCharaNeckPtn;
+
             /// <summary>
             /// Enable simultaneous kinematics on pose load
             /// </summary>
@@ -59,7 +61,11 @@ namespace KK_Plugins
             /// Set a flag when changing characters in Studio
             /// </summary>
             [HarmonyPrefix, HarmonyPatch(typeof(OCIChar), nameof(OCIChar.ChangeChara))]
-            private static void ActiveKinematicMode() => ChangingChara = true;
+            private static void ActiveKinematicMode(OCIChar __instance)
+            {
+                ChangingChara = true;
+                ChangingCharaNeckPtn = (__instance != null && __instance.neckLookCtrl != null) ? __instance.neckLookCtrl.ptnNo : -1;
+            }
 
             /// <summary>
             /// Enable simultaneous kinematics on character change. Pass the FK/IK state to the postfix
@@ -82,6 +88,8 @@ namespace KK_Plugins
             {
                 yield return null;
                 ChangingChara = false;
+                if (ChangingCharaNeckPtn != -1) ociChar.ChangeLookNeckPtn(ChangingCharaNeckPtn);
+                ChangingCharaNeckPtn = -1;
                 EnableFKIK(ociChar);
             }
         }

--- a/src/FKIK.Core/Core.FKIK.cs
+++ b/src/FKIK.Core/Core.FKIK.cs
@@ -41,6 +41,9 @@ namespace KK_Plugins
         /// </summary>
         public static void EnableFKIK(OCIChar ociChar)
         {
+
+            var origPtn = ociChar.neckLookCtrl.ptnNo;
+            
             ociChar.oiCharInfo.enableIK = true;
             ociChar.ActiveIK(BoneGroup.Body, ociChar.oiCharInfo.activeIK[0], true);
             ociChar.ActiveIK(BoneGroup.RightLeg, ociChar.oiCharInfo.activeIK[1], true);
@@ -55,15 +58,19 @@ namespace KK_Plugins
 
             for (int j = 0; j < FKCtrl.parts.Length; j++)
                 ociChar.ActiveFK(FKCtrl.parts[j], ociChar.oiCharInfo.activeFK[j], true);
+
+            if (origPtn != ociChar.neckLookCtrl.ptnNo) ociChar.ChangeLookNeckPtn(origPtn);
         }
 
         internal static void DisableFKIK(OCIChar ociChar)
         {
+            var origPtn = ociChar.neckLookCtrl.ptnNo;
             ociChar.oiCharInfo.enableIK = false;
             ociChar.oiCharInfo.enableFK = false;
             ociChar.finalIK.enabled = true;
             ociChar.ActiveKinematicMode(OICharInfo.KinematicMode.IK, false, true);
             ociChar.ActiveKinematicMode(OICharInfo.KinematicMode.FK, false, true);
+            if (origPtn != ociChar.neckLookCtrl.ptnNo) ociChar.ChangeLookNeckPtn(origPtn);
         }
 
         internal static void ToggleFKIK(bool toggle)


### PR DESCRIPTION
Now behaves the same on scene load, character replacement as vanilla. Also fixed loosing setting when toggling FKIK on/off.