### PR TITLE
[Pushup] Fix KK project, replace KKS exclusive code in shared project

### DIFF
--- a/src/Pushup.Core/Core.Pushup.GUI.cs
+++ b/src/Pushup.Core/Core.Pushup.GUI.cs
@@ -129,7 +129,7 @@ namespace KK_Plugins
             var options = GetCoordinateList();
             CoordinateDropdownTMP.AddOptions(options);
             if (value < options.Count)
-                CoordinateDropdownTMP.SetValue(value);
+                CoordinateDropdownTMP.value = value;
         }
 #endif
 

--- a/src/Pushup.KK/KK.Pushup.csproj
+++ b/src/Pushup.KK/KK.Pushup.csproj
@@ -29,6 +29,6 @@
   <ItemGroup>
     <ProjectReference Include="..\MoreOutfits.KK\KK.MoreOutfits.csproj" />
   </ItemGroup>
+  <Import Project="..\Pushup.Core\Pushup.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
-  <Import Project="..\Profile.Core\Profile.Core.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
Fix to KK.Pushup project so it builds as Pushup and not Profile, also changed code in shared project so it doesn't use function only available in KKS. Should be no side effects since setter for `value` property in KKS calls this method anyway, but it allows KK version to build.