### PR TITLE
[ME] Remove label from toggle if label string is empty

### DIFF
--- a/src/UIUtility/UIUtility.cs
+++ b/src/UIUtility/UIUtility.cs
@@ -210,6 +210,7 @@ namespace UILib
                 Object.Destroy(text.gameObject);
             else
             {
+                text.font = defaultFont;
                 text.resizeTextForBestFit = true;
                 text.resizeTextMinSize = 2;
                 text.resizeTextMaxSize = 100;


### PR DESCRIPTION
Mainly remove invisible yet clickable label from "persist search" toggle that ends up somewhere near close button