### PR TITLE
[SS] Fix shader edited check always assuming ObjectType.Clothing

### DIFF
--- a/src/ShaderSwapper.Core/ShaderSwapper.cs
+++ b/src/ShaderSwapper.Core/ShaderSwapper.cs
@@ -608,7 +608,7 @@ namespace KK_Plugins
 
         private void SwapToVanillaPlus(MaterialEditorCharaController controller, int slot, ObjectType objectType, Material mat, GameObject go, bool forceSwap)
         {
-            if (controller.GetMaterialShader(slot, ObjectType.Clothing, mat, go) == null || forceSwap)
+            if (controller.GetMaterialShader(slot, objectType, mat, go) == null || forceSwap)
             {
                 string oldShader = mat.shader.name;
                 if (!SwapStudioShadersOnCharacter.Value)


### PR DESCRIPTION
The SwapToVanillaPlus() method for characters would always check against the the clothing shaders to decide if it should swap or not, regardless of the ObjectType being passed to the method. This means, if the method  is called to swap a material on anything but the clothing, it will try to check if there are Edits saved in ME but claim that its an Clothing ObjectType. This mismatch would result in the lookup failing and returning null, so it would think the shader is unedited and swap it. 