### PR TITLE
Move common package references to build props; Update some packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
 		<FileAlignment>512</FileAlignment>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(Configuration)' == 'Debug'" >
+	<ItemGroup Condition="'$(Configuration)' == 'Debug'">
 		<PackageReference Include="BepInEx.Analyzers" Version="1.*" />
 		<PackageReference Include="Microsoft.Unity.Analyzers" Version="1.*" />
 	</ItemGroup>
@@ -25,6 +25,39 @@
 		<!--Add constants based on the project name e.g. KK-KKS.Fix_DynamicBones -> KK;KKS;Fix;DynamicBones-->
 		<DefineConstants>$(MSBuildProjectName.Replace('.',';').Replace('-',';').Replace('_',';'))</DefineConstants>
 	</PropertyGroup>
+
+	<!--Add common nuget packages based on the project name. Must use regex in this way to avoid KK matching KKS, HS matching HS2, etc.-->
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';PC;'))">
+		<PackageReference Include="IllusionLibs.BepInEx" Version="5.*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';PH;'))">
+		<PackageReference Include="ExtensibleSaveFormat.PlayHome" Version="21.0" />
+		<PackageReference Include="IllusionLibs.PlayHome.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';HS;'))">
+		<PackageReference Include="IllusionLibs.HoneySelect.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';AI;'))">
+		<PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="21.0" />
+		<PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';HS2;'))">
+		<PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="21.0" />
+		<PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';EC;'))">
+		<PackageReference Include="ExtensibleSaveFormat.EmotionCreators" Version="21.0" />
+		<PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';KK;'))">
+		<PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="21.0" />
+		<PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
+		<PackageReference Include="KoikatuCompatibilityAnalyzer" Version="*" />
+	</ItemGroup>
+	<ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(';$(DefineConstants);', ';KKS;'))">
+		<PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="21.0" />
+		<PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
+	</ItemGroup>
 
 	<!--Delete unnecessary .deps.json file in build output since it's not used in plugins-->
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/src/AccessoryClothes.EC/EC.AccessoryClothes.csproj
+++ b/src/AccessoryClothes.EC/EC.AccessoryClothes.csproj
@@ -4,9 +4,7 @@
     <AssemblyName>KK_AccessoryClothes</AssemblyName>
     <FinalAssName>EC_AccessoryClothes</FinalAssName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\AccessoryClothes.Core\AccessoryClothes.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/AccessoryClothes.KK/KK.AccessoryClothes.csproj
+++ b/src/AccessoryClothes.KK/KK.AccessoryClothes.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_AccessoryClothes</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\AccessoryClothes.Core\AccessoryClothes.Core.projitems" Label="Shared" />
 </Project>

--- a/src/AccessoryClothes.KKS/KKS.AccessoryClothes.csproj
+++ b/src/AccessoryClothes.KKS/KKS.AccessoryClothes.csproj
@@ -4,9 +4,7 @@
     <AssemblyName>KK_AccessoryClothes</AssemblyName>
     <FinalAssName>KKS_AccessoryClothes</FinalAssName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\AccessoryClothes.Core\AccessoryClothes.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/AccessoryQuickRemove.EC/EC.AccessoryQuickRemove.csproj
+++ b/src/AccessoryQuickRemove.EC/EC.AccessoryQuickRemove.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_AccessoryQuickRemove</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\AccessoryQuickRemove.Core\AccessoryQuickRemove.Core.projitems" Label="Shared" />

--- a/src/AccessoryQuickRemove.KK/KK.AccessoryQuickRemove.csproj
+++ b/src/AccessoryQuickRemove.KK/KK.AccessoryQuickRemove.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_AccessoryQuickRemove</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/AccessoryQuickRemove.KKS/KKS.AccessoryQuickRemove.csproj
+++ b/src/AccessoryQuickRemove.KKS/KKS.AccessoryQuickRemove.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_AccessoryQuickRemove</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/AnimationController.AI/AI.AnimationController.csproj
+++ b/src/AnimationController.AI/AI.AnimationController.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_AnimationController</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/AnimationController.HS2/HS2.AnimationController.csproj
+++ b/src/AnimationController.HS2/HS2.AnimationController.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_AnimationController</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\AnimationController.Core\Core.AnimationController.projitems" Label="Shared" />

--- a/src/AnimationController.KK/KK.AnimationController.csproj
+++ b/src/AnimationController.KK/KK.AnimationController.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_AnimationController</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/AnimationController.KKS/KKS.AnimationController.csproj
+++ b/src/AnimationController.KKS/KKS.AnimationController.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_AnimationController</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/AnimationOverdrive.AI/AI.AnimationOverdrive.csproj
+++ b/src/AnimationOverdrive.AI/AI.AnimationOverdrive.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_AnimationOverdrive</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\AnimationOverdrive.Core\Core.AnimationOverdrive.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/AnimationOverdrive.HS2/HS2.AnimationOverdrive.csproj
+++ b/src/AnimationOverdrive.HS2/HS2.AnimationOverdrive.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_AnimationOverdrive</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\AnimationOverdrive.Core\Core.AnimationOverdrive.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/AnimationOverdrive.KK/KK.AnimationOverdrive.csproj
+++ b/src/AnimationOverdrive.KK/KK.AnimationOverdrive.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_AnimationOverdrive</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\AnimationOverdrive.Core\Core.AnimationOverdrive.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/AnimationOverdrive.KKS/KKS.AnimationOverdrive.csproj
+++ b/src/AnimationOverdrive.KKS/KKS.AnimationOverdrive.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_AnimationOverdrive</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\AnimationOverdrive.Core\Core.AnimationOverdrive.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Autosave.AI/AI.Autosave.csproj
+++ b/src/Autosave.AI/AI.Autosave.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_Autosave</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />

--- a/src/Autosave.EC/EC.Autosave.csproj
+++ b/src/Autosave.EC/EC.Autosave.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_Autosave</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />

--- a/src/Autosave.HS/HS.Autosave.csproj
+++ b/src/Autosave.HS/HS.Autosave.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>HS_Autosave</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Autosave.HS2/HS2.Autosave.csproj
+++ b/src/Autosave.HS2/HS2.Autosave.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_Autosave</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />

--- a/src/Autosave.KK/KK.Autosave.csproj
+++ b/src/Autosave.KK/KK.Autosave.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_Autosave</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />

--- a/src/Autosave.KKS/KKS.Autosave.csproj
+++ b/src/Autosave.KKS/KKS.Autosave.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_Autosave</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/Autosave.PC/PC.Autosave.csproj
+++ b/src/Autosave.PC/PC.Autosave.csproj
@@ -18,9 +18,6 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-  </ItemGroup>
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Autosave.PH/PH.Autosave.csproj
+++ b/src/Autosave.PH/PH.Autosave.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>PH_Autosave</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.PlayHome.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.PHAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />

--- a/src/Autosave.SBPR/SBPR.Autosave.csproj
+++ b/src/Autosave.SBPR/SBPR.Autosave.csproj
@@ -23,7 +23,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
+    <PackageReference Include="IllusionLibs.BepInEx" Version="5.*" />
   </ItemGroup>
   <Import Project="..\Autosave.Core\Autosave.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/Boop.KK/KK.Boop.csproj
+++ b/src/Boop.KK/KK.Boop.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_Boop</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Boop.Core\Boop.Core.projitems" Label="Shared" />

--- a/src/Boop.KKS/KKS.Boop.csproj
+++ b/src/Boop.KKS/KKS.Boop.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_Boop</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Boop.Core\Boop.Core.projitems" Label="Shared" />

--- a/src/CharaMakerLoadedSound.KK/KK.CharaMakerLoadedSound.csproj
+++ b/src/CharaMakerLoadedSound.KK/KK.CharaMakerLoadedSound.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_CharaMakerLoadedSound</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/CharaMakerLoadedSound.KKS/KKS.CharaMakerLoadedSound.csproj
+++ b/src/CharaMakerLoadedSound.KKS/KKS.CharaMakerLoadedSound.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_CharaMakerLoadedSound</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/CharacterExport.AI/AI.CharacterExport.csproj
+++ b/src/CharacterExport.AI/AI.CharacterExport.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_CharacterExport</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\CharacterExport.Core\Core.CharacterExport.projitems" Label="Shared" />
 </Project>

--- a/src/CharacterExport.EC/EC.CharacterExport.csproj
+++ b/src/CharacterExport.EC/EC.CharacterExport.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>EC_CharacterExport</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\CharacterExport.Core\Core.CharacterExport.projitems" Label="Shared" />
 </Project>

--- a/src/CharacterExport.HS2/HS2.CharacterExport.csproj
+++ b/src/CharacterExport.HS2/HS2.CharacterExport.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_CharacterExport</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\CharacterExport.Core\Core.CharacterExport.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/CharacterExport.KK/KK.CharacterExport.csproj
+++ b/src/CharacterExport.KK/KK.CharacterExport.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_CharacterExport</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\CharacterExport.Core\Core.CharacterExport.projitems" Label="Shared" />
 </Project>

--- a/src/CharacterExport.KKS/KKS.CharacterExport.csproj
+++ b/src/CharacterExport.KKS/KKS.CharacterExport.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_CharacterExport</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\CharacterExport.Core\Core.CharacterExport.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/ClothesToAccessories.KK/KK.ClothesToAccessories.csproj
+++ b/src/ClothesToAccessories.KK/KK.ClothesToAccessories.csproj
@@ -4,9 +4,8 @@
     <AssemblyName>KK_ClothesToAccessories</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
-    <PackageReference Include="Sideloader.Koikatu" Version="19.4" />
+    <PackageReference Include="Sideloader.Koikatu" Version="21.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\ClothesToAccessories.Common\ClothesToAccessories.Common.projitems" Label="Shared" />

--- a/src/ClothesToAccessories.KKS/KKS.ClothesToAccessories.csproj
+++ b/src/ClothesToAccessories.KKS/KKS.ClothesToAccessories.csproj
@@ -4,9 +4,8 @@
     <AssemblyName>KKS_ClothesToAccessories</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
-    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="19.4" />
+    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="21.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\ClothesToAccessories.Common\ClothesToAccessories.Common.projitems" Label="Shared" />

--- a/src/ClothingUnlocker.EC/EC.ClothingUnlocker.csproj
+++ b/src/ClothingUnlocker.EC/EC.ClothingUnlocker.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_ClothingUnlocker</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\ClothingUnlocker.Core\Core.ClothingUnlocker.projitems" Label="Shared" />

--- a/src/ClothingUnlocker.KK/KK.ClothingUnlocker.csproj
+++ b/src/ClothingUnlocker.KK/KK.ClothingUnlocker.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_ClothingUnlocker</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\ClothingUnlocker.Core\Core.ClothingUnlocker.projitems" Label="Shared" />

--- a/src/ClothingUnlocker.KKS/KKS.ClothingUnlocker.csproj
+++ b/src/ClothingUnlocker.KKS/KKS.ClothingUnlocker.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_ClothingUnlocker</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/Colliders.AI/AI.Colliders.csproj
+++ b/src/Colliders.AI/AI.Colliders.csproj
@@ -10,7 +10,6 @@
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Colliders.Core\Core.Colliders.projitems" Label="Shared" />

--- a/src/Colliders.HS2/HS2.Colliders.csproj
+++ b/src/Colliders.HS2/HS2.Colliders.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_Colliders</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/Colliders.KK/KK.Colliders.csproj
+++ b/src/Colliders.KK/KK.Colliders.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_Colliders</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Colliders.Core\Core.Colliders.projitems" Label="Shared" />

--- a/src/Colliders.KKS/KKS.Colliders.csproj
+++ b/src/Colliders.KKS/KKS.Colliders.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_Colliders</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/Demosaic.AI/AI.Demosaic.csproj
+++ b/src/Demosaic.AI/AI.Demosaic.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_Demosaic</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Demosaic.Core\Core.Demosaic.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/Demosaic.EC/EC.Demosaic.csproj
+++ b/src/Demosaic.EC/EC.Demosaic.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>EC_Demosaic</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Demosaic.Core\Core.Demosaic.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/Demosaic.HS2/HS2.Demosaic.csproj
+++ b/src/Demosaic.HS2/HS2.Demosaic.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_Demosaic</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Demosaic.Core\Core.Demosaic.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/Demosaic.KK/KK.Demosaic.csproj
+++ b/src/Demosaic.KK/KK.Demosaic.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_Demosaic</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\Demosaic.Core\Core.Demosaic.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/Demosaic.KKS/KKS.Demosaic.csproj
+++ b/src/Demosaic.KKS/KKS.Demosaic.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_Demosaic</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\Demosaic.Core\Core.Demosaic.projitems" Label="Shared" />
 

--- a/src/DynamicBoneEditor.AI/AI.DynamicBoneEditor.csproj
+++ b/src/DynamicBoneEditor.AI/AI.DynamicBoneEditor.csproj
@@ -4,7 +4,6 @@
 		<AssemblyName>AI_DynamicBoneEditor</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
 		<PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1">
 		  
 		  

--- a/src/DynamicBoneEditor.EC/EC.DynamicBoneEditor.csproj
+++ b/src/DynamicBoneEditor.EC/EC.DynamicBoneEditor.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_DynamicBoneEditor</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/DynamicBoneEditor.HS2/HS2.DynamicBoneEditor.csproj
+++ b/src/DynamicBoneEditor.HS2/HS2.DynamicBoneEditor.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_DynamicBoneEditor</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\DynamicBoneEditor.Core\DynamicBoneEditor.Core.projitems" Label="Shared" />

--- a/src/DynamicBoneEditor.KK/KK.DynamicBoneEditor.csproj
+++ b/src/DynamicBoneEditor.KK/KK.DynamicBoneEditor.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_DynamicBoneEditor</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/DynamicBoneEditor.KKS/KKS.DynamicBoneEditor.csproj
+++ b/src/DynamicBoneEditor.KKS/KKS.DynamicBoneEditor.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_DynamicBoneEditor</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/DynamicBoneEditor.PH/PH.DynamicBoneEditor.csproj
+++ b/src/DynamicBoneEditor.PH/PH.DynamicBoneEditor.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>PH_DynamicBoneEditor</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.PlayHome.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.PHAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\DynamicBoneEditor.Core\DynamicBoneEditor.Core.projitems" Label="Shared" />

--- a/src/EyeControl.AI/AI.EyeControl.csproj
+++ b/src/EyeControl.AI/AI.EyeControl.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_EyeControl</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\EyeControl.Core\EyeControl.Core.projitems" Label="Shared" />

--- a/src/EyeControl.EC/EC.EyeControl.csproj
+++ b/src/EyeControl.EC/EC.EyeControl.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_EyeControl</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\EyeControl.Core\EyeControl.Core.projitems" Label="Shared" />

--- a/src/EyeControl.HS2/HS2.EyeControl.csproj
+++ b/src/EyeControl.HS2/HS2.EyeControl.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_EyeControl</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\EyeControl.Core\EyeControl.Core.projitems" Label="Shared" />

--- a/src/EyeControl.KK/KK.EyeControl.csproj
+++ b/src/EyeControl.KK/KK.EyeControl.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_EyeControl</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/EyeControl.KKS/KKS.EyeControl.csproj
+++ b/src/EyeControl.KKS/KKS.EyeControl.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_EyeControl</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/EyeShaking.KK/KK.EyeShaking.csproj
+++ b/src/EyeShaking.KK/KK.EyeShaking.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_EyeShaking</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/EyeShaking.KKS/KKS.EyeShaking.csproj
+++ b/src/EyeShaking.KKS/KKS.EyeShaking.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_EyeShaking</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/FKIK.AI/AI.FKIK.csproj
+++ b/src/FKIK.AI/AI.FKIK.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_FKIK</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\FKIK.Core\Core.FKIK.projitems" Label="Shared" />

--- a/src/FKIK.HS2/HS2.FKIK.csproj
+++ b/src/FKIK.HS2/HS2.FKIK.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_FKIK</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\FKIK.Core\Core.FKIK.projitems" Label="Shared" />

--- a/src/FKIK.KK/KK.FKIK.csproj
+++ b/src/FKIK.KK/KK.FKIK.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_FKIK</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\FKIK.Core\Core.FKIK.projitems" Label="Shared" />

--- a/src/FKIK.KKS/KKS.FKIK.csproj
+++ b/src/FKIK.KKS/KKS.FKIK.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_FKIK</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\FKIK.Core\Core.FKIK.projitems" Label="Shared" />

--- a/src/FadeAdjuster.KK/KK.FadeAdjuster.csproj
+++ b/src/FadeAdjuster.KK/KK.FadeAdjuster.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_FadeAdjuster</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\FadeAdjuster.Core\FadeAdjuster.Core.projitems" Label="Shared" />
 </Project>

--- a/src/FadeAdjuster.KKS/KKS.FadeAdjuster.csproj
+++ b/src/FadeAdjuster.KKS/KKS.FadeAdjuster.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_FadeAdjuster</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\FadeAdjuster.Core\FadeAdjuster.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/ForceHighPoly.KK/KK.ForceHighPoly.csproj
+++ b/src/ForceHighPoly.KK/KK.ForceHighPoly.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\UncensorSelector.KK\KK.UncensorSelector.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/ForceHighPoly.KKS/KKS.ForceHighPoly.csproj
+++ b/src/ForceHighPoly.KKS/KKS.ForceHighPoly.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\UncensorSelector.KKS\KKS.UncensorSelector.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/FreeHRandom.KK/KK.FreeHRandom.csproj
+++ b/src/FreeHRandom.KK/KK.FreeHRandom.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_FreeHRandom</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\FreeHRandom.Core\FreeHRandom.Core.projitems" Label="Shared" />

--- a/src/FreeHRandom.KKS/KKS.FreeHRandom.csproj
+++ b/src/FreeHRandom.KKS/KKS.FreeHRandom.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_FreeHRandom</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\FreeHRandom.Core\FreeHRandom.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />

--- a/src/FreeHStudioSceneLoader.KK/KK.FreeHStudioSceneLoader.csproj
+++ b/src/FreeHStudioSceneLoader.KK/KK.FreeHStudioSceneLoader.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_FreeHStudioSceneLoader</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
   <!--Obsolete/broken plugin, do not create releases-->

--- a/src/HCharaAdjustment.KK/KK.HCharaAdjustment.csproj
+++ b/src/HCharaAdjustment.KK/KK.HCharaAdjustment.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_HCharaAdjustment</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/HCharaAdjustment.KKS/KKS.HCharaAdjustment.csproj
+++ b/src/HCharaAdjustment.KKS/KKS.HCharaAdjustment.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_HCharaAdjustment</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/HairAccessoryCustomizer.EC/EC.HairAccessoryCustomizer.csproj
+++ b/src/HairAccessoryCustomizer.EC/EC.HairAccessoryCustomizer.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_HairAccessoryCustomizer</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\HairAccessoryCustomizer.Core\Core.HairAccessoryCustomizer.projitems" Label="Shared" />

--- a/src/HairAccessoryCustomizer.KK/KK.HairAccessoryCustomizer.csproj
+++ b/src/HairAccessoryCustomizer.KK/KK.HairAccessoryCustomizer.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_HairAccessoryCustomizer</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\HairAccessoryCustomizer.Core\Core.HairAccessoryCustomizer.projitems" Label="Shared" />

--- a/src/HairAccessoryCustomizer.KKS/KKS.HairAccessoryCustomizer.csproj
+++ b/src/HairAccessoryCustomizer.KKS/KKS.HairAccessoryCustomizer.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_HairAccessoryCustomizer</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/InvisibleBody.AI/AI.InvisibleBody.csproj
+++ b/src/InvisibleBody.AI/AI.InvisibleBody.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_InvisibleBody</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\InvisibleBody.Core\Core.InvisibleBody.projitems" Label="Shared" />

--- a/src/InvisibleBody.EC/EC.InvisibleBody.csproj
+++ b/src/InvisibleBody.EC/EC.InvisibleBody.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_InvisibleBody</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\InvisibleBody.Core\Core.InvisibleBody.projitems" Label="Shared" />

--- a/src/InvisibleBody.HS2/HS2.InvisibleBody.csproj
+++ b/src/InvisibleBody.HS2/HS2.InvisibleBody.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_InvisibleBody</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\InvisibleBody.Core\Core.InvisibleBody.projitems" Label="Shared" />

--- a/src/InvisibleBody.KK/KK.InvisibleBody.csproj
+++ b/src/InvisibleBody.KK/KK.InvisibleBody.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_InvisibleBody</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\InvisibleBody.Core\Core.InvisibleBody.projitems" Label="Shared" />

--- a/src/InvisibleBody.KKS/KKS.InvisibleBody.csproj
+++ b/src/InvisibleBody.KKS/KKS.InvisibleBody.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_InvisibleBody</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/ItemBlacklist.EC/EC.ItemBlacklist.csproj
+++ b/src/ItemBlacklist.EC/EC.ItemBlacklist.csproj
@@ -4,9 +4,8 @@
     <AssemblyName>EC_ItemBlacklist</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.EmotionCreators" Version="19.4" />
+    <PackageReference Include="Sideloader.EmotionCreators" Version="21.0" />
   </ItemGroup>
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/ItemBlacklist.KK/KK.ItemBlacklist.csproj
+++ b/src/ItemBlacklist.KK/KK.ItemBlacklist.csproj
@@ -4,10 +4,8 @@
     <AssemblyName>KK_ItemBlacklist</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
     <PackageReference Include="SharpZipLib" Version="[0.86.0,1.0)" NoWarn="NU1903, NU1902" />
-    <PackageReference Include="Sideloader.Koikatu" Version="19.4" />
+    <PackageReference Include="Sideloader.Koikatu" Version="21.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />

--- a/src/ItemBlacklist.KKS/KKS.ItemBlacklist.csproj
+++ b/src/ItemBlacklist.KKS/KKS.ItemBlacklist.csproj
@@ -4,10 +4,9 @@
     <AssemblyName>KKS_ItemBlacklist</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="19.4" />
+    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="21.0" />
   </ItemGroup>
   <Import Project="..\ItemBlacklist.Core\ItemBlacklist.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/LightingTweaks.KK/KK.LightingTweaks.csproj
+++ b/src/LightingTweaks.KK/KK.LightingTweaks.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_LightingTweaks</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/LightingTweaks.KKS/KKS.LightingTweaks.csproj
+++ b/src/LightingTweaks.KKS/KKS.LightingTweaks.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_LightingTweaks</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\LightingTweaks.Core\LightingTweaks.Core.projitems" Label="Shared" />

--- a/src/ListOverride.KK/KK.ListOverride.csproj
+++ b/src/ListOverride.KK/KK.ListOverride.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_ListOverride</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\ListOverride.Core\ListOverride.Core.projitems" Label="Shared" />
 </Project>

--- a/src/ListOverride.KKS/KKS.ListOverride.csproj
+++ b/src/ListOverride.KKS/KKS.ListOverride.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_ListOverride</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\ListOverride.Core\ListOverride.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/MakerDefaults.AI/AI.MakerDefaults.csproj
+++ b/src/MakerDefaults.AI/AI.MakerDefaults.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_MakerDefaults</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/MakerDefaults.EC/EC.MakerDefaults.csproj
+++ b/src/MakerDefaults.EC/EC.MakerDefaults.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_MakerDefaults</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/MakerDefaults.HS2/HS2.MakerDefaults.csproj
+++ b/src/MakerDefaults.HS2/HS2.MakerDefaults.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_MakerDefaults</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/MakerDefaults.KK/KK.MakerDefaults.csproj
+++ b/src/MakerDefaults.KK/KK.MakerDefaults.csproj
@@ -4,9 +4,7 @@
     <AssemblyName>KK_MakerDefaults</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\MakerDefaults.Core.KKEC\Core.MakerDefaults.KKEC.projitems" Label="Shared" />

--- a/src/MakerDefaults.KKS/KKS.MakerDefaults.csproj
+++ b/src/MakerDefaults.KKS/KKS.MakerDefaults.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_MakerDefaults</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/MaleJuice.AI/AI.MaleJuice.csproj
+++ b/src/MaleJuice.AI/AI.MaleJuice.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_MaleJuice</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="19.4" />
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\MaleJuice.Core\MaleJuice.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/MaleJuice.HS2/HS2.MaleJuice.csproj
+++ b/src/MaleJuice.HS2/HS2.MaleJuice.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_MaleJuice</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="19.4" />
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\MaleJuice.Core\MaleJuice.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/MaleJuice.KK/KK.MaleJuice.csproj
+++ b/src/MaleJuice.KK/KK.MaleJuice.csproj
@@ -3,11 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_MaleJuice</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.4" />
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\MaleJuice.Core\MaleJuice.Core.projitems" Label="Shared" />
 </Project>

--- a/src/MaleJuice.KKS/KKS.MaleJuice.csproj
+++ b/src/MaleJuice.KKS/KKS.MaleJuice.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_MaleJuice</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\MaleJuice.Core\MaleJuice.Core.projitems" Label="Shared" />

--- a/src/MaterialEditor.AI/AI.MaterialEditor.csproj
+++ b/src/MaterialEditor.AI/AI.MaterialEditor.csproj
@@ -11,11 +11,10 @@
     <EmbeddedResource Include="Resources\AI_Shaders.unity3d" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.AIGirl" Version="19.4" />
+    <PackageReference Include="Sideloader.AIGirl" Version="21.0" />
   </ItemGroup>
   <Import Project="..\MaterialEditor.Core\Core.MaterialEditor.projitems" Label="Shared" />
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />

--- a/src/MaterialEditor.API/API.MaterialEditor.csproj
+++ b/src/MaterialEditor.API/API.MaterialEditor.csproj
@@ -9,10 +9,10 @@
     <EmbeddedResource Include="Resources\default.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-    <PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="5.6.2.4" />
-    <PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="5.6.2.4" />
-    <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
+    <PackageReference Include="IllusionLibs.BepInEx" Version="5.*" />
+    <PackageReference Include="IllusionLibs.Koikatu.UnityEngine" Version="*" />
+    <PackageReference Include="IllusionLibs.Koikatu.UnityEngine.UI" Version="*" />
+    <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.*" />
   </ItemGroup>
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />
   <Import Project="..\MaterialEditor.Base\MaterialEditor.Base.projitems" Label="Shared" />

--- a/src/MaterialEditor.EC/EC.MaterialEditor.csproj
+++ b/src/MaterialEditor.EC/EC.MaterialEditor.csproj
@@ -9,11 +9,10 @@
     <EmbeddedResource Include="Resources\EC_Shaders.unity3d" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.EmotionCreators" Version="19.4" />
+    <PackageReference Include="Sideloader.EmotionCreators" Version="21.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\MaterialEditor.Core\Core.MaterialEditor.projitems" Label="Shared" />

--- a/src/MaterialEditor.HS2/HS2.MaterialEditor.csproj
+++ b/src/MaterialEditor.HS2/HS2.MaterialEditor.csproj
@@ -11,11 +11,10 @@
     <EmbeddedResource Include="Resources\default.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.HoneySelect2" Version="19.4" />
+    <PackageReference Include="Sideloader.HoneySelect2" Version="21.0" />
     <PackageReference Include="XUnity.Common" Version="1.0.0" />
     <PackageReference Include="XUnity.ResourceRedirector" Version="1.1.0" />
   </ItemGroup>

--- a/src/MaterialEditor.KK/KK.MaterialEditor.csproj
+++ b/src/MaterialEditor.KK/KK.MaterialEditor.csproj
@@ -10,12 +10,10 @@
     <EmbeddedResource Include="Resources\KK_Shaders.unity3d" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
-    <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.25.0" />
     <PackageReference Include="SharpZipLib" Version="[0.86.0,1.0)" NoWarn="NU1903, NU1902" />
-    <PackageReference Include="Sideloader.Koikatu" Version="19.4" />
+    <PackageReference Include="Sideloader.Koikatu" Version="21.0" />
   </ItemGroup>
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/MaterialEditor.KKS/KKS.MaterialEditor.csproj
+++ b/src/MaterialEditor.KKS/KKS.MaterialEditor.csproj
@@ -11,11 +11,10 @@
     <EmbeddedResource Include="Resources\default.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
-    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="19.4" />
+    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="21.0" />
   </ItemGroup>
   <Import Project="..\MaterialEditor.Base\MaterialEditor.Base.projitems" Label="Shared" />
   <Import Project="..\MaterialEditor.Core\Core.MaterialEditor.projitems" Label="Shared" />

--- a/src/MaterialEditor.PH/PH.MaterialEditor.csproj
+++ b/src/MaterialEditor.PH/PH.MaterialEditor.csproj
@@ -10,7 +10,6 @@
     <EmbeddedResource Include="Resources\default.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.PlayHome.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.ResourceRedirector" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.PHAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/MoreOutfits.KK/KK.MoreOutfits.csproj
+++ b/src/MoreOutfits.KK/KK.MoreOutfits.csproj
@@ -7,7 +7,6 @@
     <EmbeddedResource Include="Resources\ListTemplate.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\MoreOutfits.Core\MoreOutfits.Core.projitems" Label="Shared" />

--- a/src/MoreOutfits.KKS/KKS.MoreOutfits.csproj
+++ b/src/MoreOutfits.KKS/KKS.MoreOutfits.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_MoreOutfits</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/PoseQuickLoad.AI/AI.PoseQuickLoad.csproj
+++ b/src/PoseQuickLoad.AI/AI.PoseQuickLoad.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_PoseQuickLoad</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\PoseQuickLoad.Core\Core.PoseQuickLoad.projitems" Label="Shared" />
 </Project>

--- a/src/PoseQuickLoad.HS2/HS2.PoseQuickLoad.csproj
+++ b/src/PoseQuickLoad.HS2/HS2.PoseQuickLoad.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_PoseQuickLoad</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\PoseQuickLoad.Core\Core.PoseQuickLoad.projitems" Label="Shared" />
 </Project>

--- a/src/PoseQuickLoad.KK/KK.PoseQuickLoad.csproj
+++ b/src/PoseQuickLoad.KK/KK.PoseQuickLoad.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_PoseQuickLoad</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\PoseQuickLoad.Core\Core.PoseQuickLoad.projitems" Label="Shared" />
 </Project>

--- a/src/PoseQuickLoad.KKS/KKS.PoseQuickLoad.csproj
+++ b/src/PoseQuickLoad.KKS/KKS.PoseQuickLoad.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_PoseQuickLoad</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\PoseQuickLoad.Core\Core.PoseQuickLoad.projitems" Label="Shared" />
 </Project>

--- a/src/PoseTools.AI/AI.PoseTools.csproj
+++ b/src/PoseTools.AI/AI.PoseTools.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_PoseTools</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="19.4" />
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\PoseTools.Core\Core.PoseTools.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/PoseTools.HS2/HS2.PoseTools.csproj
+++ b/src/PoseTools.HS2/HS2.PoseTools.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_PoseTools</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="19.4" />
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\PoseTools.Core\Core.PoseTools.projitems" Label="Shared" />
 </Project>

--- a/src/PoseTools.KK/KK.PoseTools.csproj
+++ b/src/PoseTools.KK/KK.PoseTools.csproj
@@ -3,11 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_PoseTools</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.4" />
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\PoseTools.Core\Core.PoseTools.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/PoseTools.KKS/KKS.PoseTools.csproj
+++ b/src/PoseTools.KKS/KKS.PoseTools.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_PoseTools</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.4" />
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\PoseTools.Core\Core.PoseTools.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/PoseTools.PH/PH.PoseTools.csproj
+++ b/src/PoseTools.PH/PH.PoseTools.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>PH_PoseTools</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.PlayHome" Version="19.4" />
-    <PackageReference Include="IllusionLibs.PlayHome.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\PoseTools.Core\Core.PoseTools.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/PoseUnlocker.AI/AI.PoseUnlocker.csproj
+++ b/src/PoseUnlocker.AI/AI.PoseUnlocker.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_PoseUnlocker</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\PoseUnlocker.Core\PoseUnlocker.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/PoseUnlocker.HS2/HS2.PoseUnlocker.csproj
+++ b/src/PoseUnlocker.HS2/HS2.PoseUnlocker.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_PoseUnlocker</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\PoseUnlocker.Core\PoseUnlocker.Core.projitems" Label="Shared" />
 

--- a/src/PoseUnlocker.KK/KK.PoseUnlocker.csproj
+++ b/src/PoseUnlocker.KK/KK.PoseUnlocker.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_PoseUnlocker</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\PoseUnlocker.Core\PoseUnlocker.Core.projitems" Label="Shared" />
 

--- a/src/PoseUnlocker.KKS/KKS.PoseUnlocker.csproj
+++ b/src/PoseUnlocker.KKS/KKS.PoseUnlocker.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_PoseUnlocker</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\PoseUnlocker.Core\PoseUnlocker.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 

--- a/src/Profile.EC/EC.Profile.csproj
+++ b/src/Profile.EC/EC.Profile.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_Profile</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/Profile.KK/KK.Profile.csproj
+++ b/src/Profile.KK/KK.Profile.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_Profile</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/Profile.KKS/KKS.Profile.csproj
+++ b/src/Profile.KKS/KKS.Profile.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_Profile</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/Pushup.EC/EC.Pushup.csproj
+++ b/src/Pushup.EC/EC.Pushup.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_Pushup</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/Pushup.KK/KK.Pushup.csproj
+++ b/src/Pushup.KK/KK.Pushup.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_Pushup</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Pushup.KKS/KKS.Pushup.csproj
+++ b/src/Pushup.KKS/KKS.Pushup.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_Pushup</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/RandomCharacterGenerator.KK/KK.RandomCharacterGenerator.csproj
+++ b/src/RandomCharacterGenerator.KK/KK.RandomCharacterGenerator.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_RandomCharacterGenerator</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/RandomCharacterGenerator.KKS/KKS.RandomCharacterGenerator.csproj
+++ b/src/RandomCharacterGenerator.KKS/KKS.RandomCharacterGenerator.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_RandomCharacterGenerator</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\RandomCharacterGenerator.Core\RandomCharacterGenerator.Core.projitems" Label="Shared" />

--- a/src/ReloadCharaListOnChange.EC/EC.ReloadCharaListOnChange.csproj
+++ b/src/ReloadCharaListOnChange.EC/EC.ReloadCharaListOnChange.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>EC_ReloadCharaListOnChange</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/ReloadCharaListOnChange.KK/KK.ReloadCharaListOnChange.csproj
+++ b/src/ReloadCharaListOnChange.KK/KK.ReloadCharaListOnChange.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_ReloadCharaListOnChange</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/ReloadCharaListOnChange.KKS/KKS.ReloadCharaListOnChange.csproj
+++ b/src/ReloadCharaListOnChange.KKS/KKS.ReloadCharaListOnChange.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_ReloadCharaListOnChange</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionLibs.XUnity.AutoTranslator.Plugin.Core" Version="4.18.0" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>

--- a/src/ShaderSwapper.KK/KK.ShaderSwapper.csproj
+++ b/src/ShaderSwapper.KK/KK.ShaderSwapper.csproj
@@ -7,7 +7,7 @@
     <ProjectReference Include="..\MaterialEditor.KK\KK.MaterialEditor.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ScreenshotManager.Koikatu" Version="19.4" />
+    <PackageReference Include="ScreenshotManager.Koikatu" Version="21.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\ShaderSwapper.Core\ShaderSwapper.Core.projitems" Label="Shared" />

--- a/src/ShaderSwapper.KKS/KKS.ShaderSwapper.csproj
+++ b/src/ShaderSwapper.KKS/KKS.ShaderSwapper.csproj
@@ -7,7 +7,7 @@
     <ProjectReference Include="..\MaterialEditor.KKS\KKS.MaterialEditor.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="19.4" />
+    <PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="21.0" />
   </ItemGroup>
   <Import Project="..\ShaderSwapper.Core\ShaderSwapper.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/SpawnLocker.KK/KK.SpawnLocker.csproj
+++ b/src/SpawnLocker.KK/KK.SpawnLocker.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>KK_SpawnLocker</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.Koikatu" Version="19.4" />
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\SpawnLocker.Core\SpawnLocker.Core.projitems" Label="Shared" />

--- a/src/SpawnLocker.KKS/KKS.SpawnLocker.csproj
+++ b/src/SpawnLocker.KKS/KKS.SpawnLocker.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>KKS_SpawnLocker</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.KoikatsuSunshine" Version="19.4" />
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\SpawnLocker.Core\SpawnLocker.Core.projitems" Label="Shared" />

--- a/src/StudioCustomMasking.AI/AI.StudioCustomMasking.csproj
+++ b/src/StudioCustomMasking.AI/AI.StudioCustomMasking.csproj
@@ -7,9 +7,7 @@
     <ProjectReference Include="..\StudioSceneSettings.AI\AI.StudioSceneSettings.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.AIGirl" Version="19.4" />
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-    <PackageReference Include="ScreenshotManager.AIGirl" Version="19.4" />
+    <PackageReference Include="ScreenshotManager.AIGirl" Version="21.0" />
   </ItemGroup>
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/StudioCustomMasking.HS2/HS2.StudioCustomMasking.csproj
+++ b/src/StudioCustomMasking.HS2/HS2.StudioCustomMasking.csproj
@@ -7,9 +7,7 @@
     <ProjectReference Include="..\StudioSceneSettings.HS2\HS2.StudioSceneSettings.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ExtensibleSaveFormat.HoneySelect2" Version="19.4" />
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-    <PackageReference Include="ScreenshotManager.HoneySelect2" Version="19.4" />
+    <PackageReference Include="ScreenshotManager.HoneySelect2" Version="21.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />

--- a/src/StudioCustomMasking.KK/KK.StudioCustomMasking.csproj
+++ b/src/StudioCustomMasking.KK/KK.StudioCustomMasking.csproj
@@ -7,9 +7,8 @@
     <ProjectReference Include="..\StudioSceneSettings.KK\KK.StudioSceneSettings.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
-    <PackageReference Include="ScreenshotManager.Koikatu" Version="19.4" />
+    <PackageReference Include="ScreenshotManager.Koikatu" Version="21.0" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\UIUtility\UIUtility.projitems" Label="Shared" />

--- a/src/StudioCustomMasking.KKS/KKS.StudioCustomMasking.csproj
+++ b/src/StudioCustomMasking.KKS/KKS.StudioCustomMasking.csproj
@@ -7,9 +7,8 @@
     <ProjectReference Include="..\StudioSceneSettings.KKS\KKS.StudioSceneSettings.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
-    <PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="19.4" />
+    <PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="21.0" />
   </ItemGroup>
   <Import Project="..\StudioCustomMasking.Core\StudioCustomMasking.Core.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/StudioObjectMoveHotkeys.AI/AI.StudioObjectMoveHotkeys.csproj
+++ b/src/StudioObjectMoveHotkeys.AI/AI.StudioObjectMoveHotkeys.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>AI_StudioObjectMoveHotkeys</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\StudioObjectMoveHotkeys.Core\Core.StudioObjectMoveHotkeys.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/StudioObjectMoveHotkeys.HS2/HS2.StudioObjectMoveHotkeys.csproj
+++ b/src/StudioObjectMoveHotkeys.HS2/HS2.StudioObjectMoveHotkeys.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>HS2_StudioObjectMoveHotkeys</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\StudioObjectMoveHotkeys.Core\Core.StudioObjectMoveHotkeys.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/StudioObjectMoveHotkeys.KK/KK.StudioObjectMoveHotkeys.csproj
+++ b/src/StudioObjectMoveHotkeys.KK/KK.StudioObjectMoveHotkeys.csproj
@@ -3,10 +3,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>KK_StudioObjectMoveHotkeys</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
+
   <Import Project="..\StudioObjectMoveHotkeys.Core\Core.StudioObjectMoveHotkeys.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/StudioObjectMoveHotkeys.KKS/KKS.StudioObjectMoveHotkeys.csproj
+++ b/src/StudioObjectMoveHotkeys.KKS/KKS.StudioObjectMoveHotkeys.csproj
@@ -3,9 +3,7 @@
     <TargetFramework>net46</TargetFramework>
     <AssemblyName>KKS_StudioObjectMoveHotkeys</AssemblyName>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
+
   <Import Project="..\StudioObjectMoveHotkeys.Core\Core.StudioObjectMoveHotkeys.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/StudioSceneLoadedSound.AI/AI.StudioSceneLoadedSound.csproj
+++ b/src/StudioSceneLoadedSound.AI/AI.StudioSceneLoadedSound.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_StudioSceneLoadedSound</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\StudioSceneLoadedSound.Core\Core.StudioSceneLoadedSound.projitems" Label="Shared" />

--- a/src/StudioSceneLoadedSound.HS2/HS2.StudioSceneLoadedSound.csproj
+++ b/src/StudioSceneLoadedSound.HS2/HS2.StudioSceneLoadedSound.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_StudioSceneLoadedSound</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\StudioSceneLoadedSound.Core\Core.StudioSceneLoadedSound.projitems" Label="Shared" />

--- a/src/StudioSceneLoadedSound.KK/KK.StudioSceneLoadedSound.csproj
+++ b/src/StudioSceneLoadedSound.KK/KK.StudioSceneLoadedSound.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_StudioSceneLoadedSound</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/StudioSceneLoadedSound.KKS/KKS.StudioSceneLoadedSound.csproj
+++ b/src/StudioSceneLoadedSound.KKS/KKS.StudioSceneLoadedSound.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_StudioSceneLoadedSound</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\StudioSceneLoadedSound.Core\Core.StudioSceneLoadedSound.projitems" Label="Shared" />

--- a/src/StudioSceneSettings.AI/AI.StudioSceneSettings.csproj
+++ b/src/StudioSceneSettings.AI/AI.StudioSceneSettings.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>AI_StudioSceneSettings</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/StudioSceneSettings.HS2/HS2.StudioSceneSettings.csproj
+++ b/src/StudioSceneSettings.HS2/HS2.StudioSceneSettings.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>HS2_StudioSceneSettings</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\StudioSceneSettings.Core\Core.StudioSceneSettings.projitems" Label="Shared" />

--- a/src/StudioSceneSettings.KK/KK.StudioSceneSettings.csproj
+++ b/src/StudioSceneSettings.KK/KK.StudioSceneSettings.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>KK_StudioSceneSettings</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/StudioSceneSettings.KKS/KKS.StudioSceneSettings.csproj
+++ b/src/StudioSceneSettings.KKS/KKS.StudioSceneSettings.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_StudioSceneSettings</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\StudioSceneSettings.Core\Core.StudioSceneSettings.projitems" Label="Shared" />

--- a/src/StudioWindowResize.AI/AI.StudioWindowResize.csproj
+++ b/src/StudioWindowResize.AI/AI.StudioWindowResize.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>AI_StudioWindowResize</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\StudioWindowResize.Core\StudioWindowResize.Core.projitems" Label="Shared" />

--- a/src/StudioWindowResize.HS2/HS2.StudioWindowResize.csproj
+++ b/src/StudioWindowResize.HS2/HS2.StudioWindowResize.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>HS2_StudioWindowResize</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\StudioWindowResize.Core\StudioWindowResize.Core.projitems" Label="Shared" />

--- a/src/StudioWindowResize.KK/KK.StudioWindowResize.csproj
+++ b/src/StudioWindowResize.KK/KK.StudioWindowResize.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_StudioWindowResize</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/StudioWindowResize.KKS/KKS.StudioWindowResize.csproj
+++ b/src/StudioWindowResize.KKS/KKS.StudioWindowResize.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KKS_StudioWindowResize</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/Subtitles.AI/AI.Subtitles.csproj
+++ b/src/Subtitles.AI/AI.Subtitles.csproj
@@ -6,9 +6,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedSubs.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
-  </ItemGroup>
   <Import Project="..\Subtitles.Core\Core.Subtitles.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Subtitles.HS/HS.Subtitles.csproj
+++ b/src/Subtitles.HS/HS.Subtitles.csproj
@@ -6,9 +6,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedSubs.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect.AllPackages" Version="*" />
-  </ItemGroup>
   <Import Project="..\Subtitles.Core\Core.Subtitles.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Subtitles.HS2/HS2.Subtitles.csproj
+++ b/src/Subtitles.HS2/HS2.Subtitles.csproj
@@ -6,9 +6,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedSubs.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
-  </ItemGroup>
   <Import Project="..\Subtitles.Core\Core.Subtitles.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Subtitles.KK/KK.Subtitles.csproj
+++ b/src/Subtitles.KK/KK.Subtitles.csproj
@@ -6,10 +6,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedSubs.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
-    <PackageReference Include="KoikatuCompatibilityAnalyzer" Version="1.1.0" />
-  </ItemGroup>
   <Import Project="..\Subtitles.Core\Core.Subtitles.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Subtitles.KKS/KKS.Subtitles.csproj
+++ b/src/Subtitles.KKS/KKS.Subtitles.csproj
@@ -6,9 +6,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedSubs.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
-  </ItemGroup>
   <Import Project="..\Subtitles.Core\Core.Subtitles.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 </Project>

--- a/src/Subtitles.PC/PC.Subtitles.csproj
+++ b/src/Subtitles.PC/PC.Subtitles.csproj
@@ -29,9 +29,6 @@
   <ItemGroup>
     <EmbeddedResource Include="Resources\EmbeddedSubs.xml" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="IllusionLibs.BepInEx" Version="5.4.22" />
-  </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\Subtitles.Core\Core.Subtitles.projitems" Label="Shared" />
 </Project>

--- a/src/TestPlugin.KK/KK.TestPlugin.csproj
+++ b/src/TestPlugin.KK/KK.TestPlugin.csproj
@@ -4,7 +4,6 @@
     <AssemblyName>KK_TestPlugin</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/TimelineFlowControl.AI/AI.TimelineFlowControl.csproj
+++ b/src/TimelineFlowControl.AI/AI.TimelineFlowControl.csproj
@@ -13,7 +13,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\TimelineFlowControl.Shared\Shared_TimelineButton.projitems" Label="Shared" />

--- a/src/TimelineFlowControl.HS2/HS2.TimelineFlowControl.csproj
+++ b/src/TimelineFlowControl.HS2/HS2.TimelineFlowControl.csproj
@@ -13,7 +13,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\TimelineFlowControl.Shared\Shared_TimelineButton.projitems" Label="Shared" />

--- a/src/TimelineFlowControl.KK/KK.TimelineFlowControl.csproj
+++ b/src/TimelineFlowControl.KK/KK.TimelineFlowControl.csproj
@@ -17,7 +17,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\TimelineFlowControl.Shared\Shared_TimelineButton.projitems" Label="Shared" />

--- a/src/TimelineFlowControl.KKS/KKS.TimelineFlowControl.csproj
+++ b/src/TimelineFlowControl.KKS/KKS.TimelineFlowControl.csproj
@@ -11,7 +11,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
   </ItemGroup>
   <Import Project="..\TimelineFlowControl.Shared\Shared_TimelineButton.projitems" Label="Shared" />

--- a/src/TwoLut.KK/KK.TwoLut.csproj
+++ b/src/TwoLut.KK/KK.TwoLut.csproj
@@ -4,9 +4,8 @@
     <AssemblyName>KK_TwoLut</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
-    <PackageReference Include="Sideloader.Koikatu" Version="19.4" />
+    <PackageReference Include="Sideloader.Koikatu" Version="21.0" />
   </ItemGroup>
   <Import Project="..\TwoLut.Shared\TwoLut.Shared.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/TwoLut.KKS/KKS.TwoLut.csproj
+++ b/src/TwoLut.KKS/KKS.TwoLut.csproj
@@ -4,9 +4,8 @@
     <AssemblyName>KKS_TwoLut</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
-    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="19.4" />
+    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="21.0" />
   </ItemGroup>
   <Import Project="..\TwoLut.Shared\TwoLut.Shared.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/UncensorSelector.AI/AI.UncensorSelector.csproj
+++ b/src/UncensorSelector.AI/AI.UncensorSelector.csproj
@@ -5,11 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BepInEx.ConfigurationManager" Version="18.2.0.1" />
-    <PackageReference Include="IllusionLibs.AIGirl.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.45.1" />
     <PackageReference Include="OverlayMods.AIGirl" Version="6.0.7" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.AIGirl" Version="19.4" />
+    <PackageReference Include="Sideloader.AIGirl" Version="21.0" />
   </ItemGroup>
   <Import Project="..\UncensorSelector.Core\Core.UncensorSelector.projitems" Label="Shared" />
   <Import Project="..\UncensorSelector.Core.Studio\Core.UncensorSelector.Studio.projitems" Label="Shared" />

--- a/src/UncensorSelector.EC/EC.UncensorSelector.csproj
+++ b/src/UncensorSelector.EC/EC.UncensorSelector.csproj
@@ -5,11 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BepInEx.ConfigurationManager" Version="18.2.0.1" />
-    <PackageReference Include="IllusionLibs.EmotionCreators.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.ECAPI" Version="1.45.1" />
     <PackageReference Include="OverlayMods.EmotionCreators" Version="6.0.7" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.EmotionCreators" Version="19.4" />
+    <PackageReference Include="Sideloader.EmotionCreators" Version="21.0" />
   </ItemGroup>
   <Import Project="..\UncensorSelector.Core\Core.UncensorSelector.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/UncensorSelector.HS2/HS2.UncensorSelector.csproj
+++ b/src/UncensorSelector.HS2/HS2.UncensorSelector.csproj
@@ -5,11 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BepInEx.ConfigurationManager" Version="18.2.0.1" />
-    <PackageReference Include="IllusionLibs.HoneySelect2.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.HS2API" Version="1.45.1" />
     <PackageReference Include="OverlayMods.HoneySelect2" Version="6.0.7" />
     <PackageReference Include="SharpZipLib" Version="[1.3.3,1.4)" />
-    <PackageReference Include="Sideloader.HoneySelect2" Version="19.4" />
+    <PackageReference Include="Sideloader.HoneySelect2" Version="21.0" />
     <PackageReference Include="XUnity.Common" Version="1.0.0" />
     <PackageReference Include="XUnity.ResourceRedirector" Version="1.1.0" />
   </ItemGroup>

--- a/src/UncensorSelector.KK/KK.UncensorSelector.csproj
+++ b/src/UncensorSelector.KK/KK.UncensorSelector.csproj
@@ -5,11 +5,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BepInEx.ConfigurationManager" Version="18.2.0.1" />
-    <PackageReference Include="IllusionLibs.Koikatu.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.45.1" />
     <PackageReference Include="OverlayMods.Koikatu" Version="6.0.7" />
     <PackageReference Include="SharpZipLib" Version="[0.86.0,1.0)" NoWarn="NU1903, NU1902" />
-    <PackageReference Include="Sideloader.Koikatu" Version="19.4" />
+    <PackageReference Include="Sideloader.Koikatu" Version="21.0" />
   </ItemGroup>
   <Import Project="..\UncensorSelector.Core\Core.UncensorSelector.projitems" Label="Shared" />
   <Import Project="..\UncensorSelector.Core.Studio\Core.UncensorSelector.Studio.projitems" Label="Shared" />

--- a/src/UncensorSelector.KKS/KKS.UncensorSelector.csproj
+++ b/src/UncensorSelector.KKS/KKS.UncensorSelector.csproj
@@ -5,10 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BepInEx.ConfigurationManager" Version="18.2.0.1" />
-    <PackageReference Include="IllusionLibs.KoikatsuSunshine.AllPackages" Version="*" />
     <PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.45.1" />
     <PackageReference Include="OverlayMods.KoikatsuSunshine" Version="6.0.7" />
-    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="19.4" />
+    <PackageReference Include="Sideloader.KoikatsuSunshine" Version="21.0" />
   </ItemGroup>
   <Import Project="..\UncensorSelector.Core\Core.UncensorSelector.projitems" Label="Shared" />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />


### PR DESCRIPTION
Required BepisPlugins bumped to v21.0. Always use the latest game assembly packages.